### PR TITLE
Refactor: header영역을 width 100%로 변경

### DIFF
--- a/apps/landing/src/common/Header/Header.component.tsx
+++ b/apps/landing/src/common/Header/Header.component.tsx
@@ -3,8 +3,10 @@ import { Heading, Navigation } from '@/common';
 
 const Header = () => (
   <Styled.Header>
-    <Heading />
-    <Navigation />
+    <Styled.HeaderInner>
+      <Heading />
+      <Navigation />
+    </Styled.HeaderInner>
   </Styled.Header>
 );
 

--- a/apps/landing/src/common/Header/Header.styled.ts
+++ b/apps/landing/src/common/Header/Header.styled.ts
@@ -5,18 +5,24 @@ export const Header = styled.header`
   ${({ theme }) => css`
     position: fixed;
     top: 0;
-    left: 50%;
+    left: 0;
     z-index: ${theme.zIndex.header};
+    width: 100%;
+    background: rgba(0, 0, 0, 0.8);
+    backdrop-filter: blur(1rem);
+  `}
+`;
+
+export const HeaderInner = styled.div`
+  ${({ theme }) => css`
     display: flex;
     flex-flow: row nowrap;
     align-items: center;
     justify-content: space-between;
     width: 144rem;
     height: 10rem;
+    margin: 0 auto;
     padding: 2.8rem 8rem;
-    background: rgba(0, 0, 0, 0.8);
-    transform: translate3d(-50%, 0, 0);
-    backdrop-filter: blur(1rem);
 
     @media (max-width: ${theme.breakPoint.media.notebook}) {
       width: 100%;


### PR DESCRIPTION
## 변경사항

- Header 컴포넌트의 렌더링 영역을 최대 1440px에서 화면에 꽉 차게 100%로 설정한다

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
