### PR TITLE
LinearGradientSphere컴포넌트 위에 deem 영역을 추가

### DIFF
--- a/apps/landing/src/components/main/IntroSection/IntroSection.component.tsx
+++ b/apps/landing/src/components/main/IntroSection/IntroSection.component.tsx
@@ -33,7 +33,7 @@ const IntroSection = () => (
           <Styled.GradientLine />
         </Styled.GradientLineWrapper>
       </Styled.Growth>
-      <LinearGradientSphere diameterRem={128} position="absolute" top="33.426%" left="0" />
+      <LinearGradientSphere diameter="128rem" position="absolute" top="33.426%" left="0" />
       <Styled.LinearGradientSphereDeem />
     </Styled.IntroSection>
   </DefaultLayout>

--- a/apps/landing/src/components/main/IntroSection/IntroSection.component.tsx
+++ b/apps/landing/src/components/main/IntroSection/IntroSection.component.tsx
@@ -34,6 +34,7 @@ const IntroSection = () => (
         </Styled.GradientLineWrapper>
       </Styled.Growth>
       <LinearGradientSphere diameterRem={128} position="absolute" top="33.426%" left="0" />
+      <Styled.LinearGradientSphereDeem />
     </Styled.IntroSection>
   </DefaultLayout>
 );

--- a/apps/landing/src/components/main/IntroSection/IntroSection.component.tsx
+++ b/apps/landing/src/components/main/IntroSection/IntroSection.component.tsx
@@ -1,42 +1,69 @@
 import { LinearGradientSphere } from 'ui';
 import { DefaultLayout } from '@/components/common';
 import * as Styled from './IntroSection.styled';
+import { useDetectViewport } from '@/hooks';
+import { TViewPortSize } from '@/constants';
 
-const IntroSection = () => (
-  <DefaultLayout>
-    <Styled.IntroSection>
-      <Styled.MashUp>
-        <span>MASH-UP</span>
-        <Styled.GradientLineWrapper>
-          <Styled.GradientLine />
-        </Styled.GradientLineWrapper>
-      </Styled.MashUp>
-      <Styled.Seeking>
-        <Styled.GradientLineWrapper>
-          <Styled.GradientLine />
-        </Styled.GradientLineWrapper>
-        <span>SEEKING</span>
-      </Styled.Seeking>
-      <Styled.ValueForGrowth>
-        <span>VALUE FOR GROWTH</span>
-        <Styled.GradientLineWrapper>
-          <Styled.GradientLine />
-        </Styled.GradientLineWrapper>
-      </Styled.ValueForGrowth>
+const LINEAR_GRADIENT_SPHERE_DIAMETER: Record<TViewPortSize, string> = {
+  DESKTOP: '128rem',
+  NOTEBOOK: '86.4rem',
+  TABLET_L: '64.8rem',
+  TABLET_S: '46.1rem',
+  MOBILE: '37.5rem',
+} as const;
 
-      <Styled.ValueFor>
-        <span>VALUE FOR</span>
-      </Styled.ValueFor>
-      <Styled.Growth>
-        <span>GROWTH</span>
-        <Styled.GradientLineWrapper>
-          <Styled.GradientLine />
-        </Styled.GradientLineWrapper>
-      </Styled.Growth>
-      <LinearGradientSphere diameter="128rem" position="absolute" top="33.426%" left="0" />
-      <Styled.LinearGradientSphereDeem />
-    </Styled.IntroSection>
-  </DefaultLayout>
-);
+const LINEAR_GRADIENT_SPHERE_POSITION_TOP: Record<TViewPortSize, string> = {
+  DESKTOP: '33.4259%',
+  NOTEBOOK: '32.6388%',
+  TABLET_L: '36.9444%',
+  TABLET_S: '36.9028%',
+  MOBILE: '31.6341%',
+} as const;
+
+const IntroSection = () => {
+  const { viewportSize } = useDetectViewport();
+
+  return (
+    <DefaultLayout>
+      <Styled.IntroSection>
+        <Styled.MashUp>
+          <span>MASH-UP</span>
+          <Styled.GradientLineWrapper>
+            <Styled.GradientLine />
+          </Styled.GradientLineWrapper>
+        </Styled.MashUp>
+        <Styled.Seeking>
+          <Styled.GradientLineWrapper>
+            <Styled.GradientLine />
+          </Styled.GradientLineWrapper>
+          <span>SEEKING</span>
+        </Styled.Seeking>
+        <Styled.ValueForGrowth>
+          <span>VALUE FOR GROWTH</span>
+          <Styled.GradientLineWrapper>
+            <Styled.GradientLine />
+          </Styled.GradientLineWrapper>
+        </Styled.ValueForGrowth>
+
+        <Styled.ValueFor>
+          <span>VALUE FOR</span>
+        </Styled.ValueFor>
+        <Styled.Growth>
+          <span>GROWTH</span>
+          <Styled.GradientLineWrapper>
+            <Styled.GradientLine />
+          </Styled.GradientLineWrapper>
+        </Styled.Growth>
+        <LinearGradientSphere
+          diameter={LINEAR_GRADIENT_SPHERE_DIAMETER[viewportSize]}
+          position="absolute"
+          top={LINEAR_GRADIENT_SPHERE_POSITION_TOP[viewportSize]}
+          left="0"
+        />
+        <Styled.LinearGradientSphereDeem />
+      </Styled.IntroSection>
+    </DefaultLayout>
+  );
+};
 
 export default IntroSection;

--- a/apps/landing/src/components/main/IntroSection/IntroSection.styled.ts
+++ b/apps/landing/src/components/main/IntroSection/IntroSection.styled.ts
@@ -146,10 +146,29 @@ export const GradientLine = styled.div`
 `;
 
 export const LinearGradientSphereDeem = styled.div`
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 44.44%;
-  background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, #000000 100%);
+  ${({ theme }) => css`
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    z-index: ${theme.globalZIndex.background};
+    width: 100%;
+    height: 44.44%;
+    background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, #000000 100%);
+
+    @media (max-width: ${theme.breakPoint.media.notebook}) {
+      height: 43.1944%;
+    }
+
+    @media (max-width: ${theme.breakPoint.media.tabletL}) {
+      height: 43.8888%;
+    }
+
+    @media (max-width: ${theme.breakPoint.media.tabletS}) {
+      height: 50.2471%;
+    }
+
+    @media (max-width: ${theme.breakPoint.media.mobile}) {
+      height: 50.0749%;
+    }
+  `}
 `;

--- a/apps/landing/src/components/main/IntroSection/IntroSection.styled.ts
+++ b/apps/landing/src/components/main/IntroSection/IntroSection.styled.ts
@@ -144,3 +144,12 @@ export const GradientLine = styled.div`
     }
   `}
 `;
+
+export const LinearGradientSphereDeem = styled.div`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 44.44%;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, #000000 100%);
+`;

--- a/packages/ui/LinearGradientSphere/LinearGradientSphere.component.tsx
+++ b/packages/ui/LinearGradientSphere/LinearGradientSphere.component.tsx
@@ -6,13 +6,21 @@ interface LinearGradientSphereProps extends Styled.SphereContainerProps {
 
 const LinearGradientSphere = ({
   variant = 'DEFAULT',
-  diameterRem,
+  diameter,
   ...positionProps
-}: LinearGradientSphereProps) => (
-  <Styled.SphereContainer diameterRem={diameterRem} {...positionProps}>
-    <Styled.BackLight variant={variant} diameterRem={diameterRem * 0.8333} />
-    <Styled.Sphere variant={variant} diameterRem={diameterRem} />
-  </Styled.SphereContainer>
-);
+}: LinearGradientSphereProps) => {
+  const [diameterUnit] = diameter.match(/px|em|rem|%|vh|vw/) ?? [''];
+  const diameterValue = diameter.replace(diameterUnit, '');
+
+  const BACK_LIGHT_SCALE = 0.8333;
+  const backLightDiameter = +diameterValue * BACK_LIGHT_SCALE;
+
+  return (
+    <Styled.SphereContainer diameter={diameter} {...positionProps}>
+      <Styled.BackLight variant={variant} diameter={`${+backLightDiameter}${diameterUnit}`} />
+      <Styled.Sphere variant={variant} diameter={diameter} />
+    </Styled.SphereContainer>
+  );
+};
 
 export default LinearGradientSphere;

--- a/packages/ui/LinearGradientSphere/LinearGradientSphere.styled.ts
+++ b/packages/ui/LinearGradientSphere/LinearGradientSphere.styled.ts
@@ -39,8 +39,10 @@ const SPHERE_COLOR = {
   NODE: 'linear-gradient(180deg, #580000 -3.9%, #000000 20.31%)',
 };
 
+type TDiameter = string;
+
 export interface SphereContainerProps {
-  diameterRem: number;
+  diameter: TDiameter;
   position?: 'relative' | 'absolute' | 'static' | 'fixed' | 'sticky';
   top?: string;
   bottom?: string;
@@ -49,7 +51,7 @@ export interface SphereContainerProps {
 }
 
 export const SphereContainer = styled.div<SphereContainerProps>`
-  ${({ theme, diameterRem, position = 'relative', top, bottom, left, right }) => css`
+  ${({ theme, diameter, position = 'relative', top, bottom, left, right }) => css`
     position: ${position};
     top: ${top ? `${top}` : 'unset'};
     right: ${right ? `${right}` : 'unset'};
@@ -60,31 +62,31 @@ export const SphereContainer = styled.div<SphereContainerProps>`
     flex-direction: column;
     align-items: center;
     width: 100%;
-    height: ${diameterRem}rem;
+    height: ${diameter};
     opacity: 0.7;
   `}
 `;
 
-export const BackLight = styled.div<{ variant?: TSphereVariants; diameterRem: number }>`
-  ${({ variant, diameterRem }) => css`
+export const BackLight = styled.div<{ variant?: TSphereVariants; diameter: TDiameter }>`
+  ${({ variant, diameter }) => css`
     position: absolute;
     top: -0.5rem;
-    width: ${diameterRem}rem;
-    height: ${diameterRem}rem;
+    width: ${diameter};
+    height: ${diameter};
     background: ${variant ? SPHERE_BACKLIGHT_COLOR[variant] : SPHERE_BACKLIGHT_COLOR.DEFAULT};
-    border-radius: ${diameterRem}rem;
+    border-radius: ${diameter};
     opacity: 0.8;
     filter: blur(6.4rem);
   `}
 `;
 
-export const Sphere = styled.div<{ variant?: TSphereVariants; diameterRem: number }>`
-  ${({ variant, diameterRem }) => css`
+export const Sphere = styled.div<{ variant?: TSphereVariants; diameter: TDiameter }>`
+  ${({ variant, diameter }) => css`
     position: absolute;
-    width: ${diameterRem}rem;
-    height: ${diameterRem}rem;
+    width: ${diameter};
+    height: ${diameter};
     background: ${variant ? SPHERE_COLOR[variant] : SPHERE_COLOR.DEFAULT};
-    border-radius: ${diameterRem}rem;
+    border-radius: ${diameter};
     box-shadow: ${variant ? BOX_SHADOW[variant] : BOX_SHADOW.DEFAULT};
   `}
 `;


### PR DESCRIPTION
## 변경사항

- 디자인상 존재하는 LinearGradientSphere컴포넌트 위에 있는 deem 영역을 추가
- LinearGradientSphere 컴포넌트의 diameter를 다양한 단위(px, rem, %)등으로 사용할 수 있도록 수정

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
