### PR TITLE
SnapParent의 props에 axis와 strictness를 추가

### DIFF
--- a/apps/landing/src/components/common/SnapParent/SnapParent.component.tsx
+++ b/apps/landing/src/components/common/SnapParent/SnapParent.component.tsx
@@ -1,9 +1,15 @@
-import { PropsWithChildren } from 'react';
+import { ReactNode } from 'react';
 
 import * as Styled from './SnapParent.styled';
 
-const SnapParent = ({ children }: PropsWithChildren) => (
-  <Styled.SnapParent>{children}</Styled.SnapParent>
+interface SnapParentProps extends Styled.SnapParentProps {
+  children: ReactNode;
+}
+
+const SnapParent = ({ axis, strictness, children }: SnapParentProps) => (
+  <Styled.SnapParent axis={axis} strictness={strictness}>
+    {children}
+  </Styled.SnapParent>
 );
 
 export default SnapParent;

--- a/apps/landing/src/components/common/SnapParent/SnapParent.styled.ts
+++ b/apps/landing/src/components/common/SnapParent/SnapParent.styled.ts
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-interface SnapParentProps {
+export interface SnapParentProps {
   axis?: 'x' | 'y';
   strictness?: 'proximity' | 'mandatory';
 }


### PR DESCRIPTION
## 변경사항

- SnapParent의 props에 axis와 strictness를 추가하여 원하는 축과 엄격도를 전달하여 사용할 수 있도록 한다

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가


### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
