### PR TITLE
IntroSection에 잘못 적용된 padding을 IntroSectionLayout으로 이동

### DIFF
--- a/apps/landing/src/components/main/IntroSection/IntroSection.styled.ts
+++ b/apps/landing/src/components/main/IntroSection/IntroSection.styled.ts
@@ -5,24 +5,24 @@ import { fonts } from 'theme';
 import { breakPoint } from '@/styles/breakPoint';
 
 export const IntroSection = styled.section`
+  position: relative;
+  height: 100vh;
+  max-height: 100vh;
+  overflow: hidden;
+  scroll-snap-align: center;
+`;
+
+export const IntroSectionLayout = styled.div`
   ${({ theme }) => css`
-    position: relative;
-    height: 100vh;
-    max-height: 100vh;
-    overflow: hidden;
-    scroll-snap-align: center;
+    display: flex;
+    flex-flow: column nowrap;
+    justify-content: center;
+    height: 100%;
 
     @media (max-width: ${theme.breakPoint.media.mobile}) {
       padding: 0 1.8rem 0 1.9rem;
     }
   `}
-`;
-
-export const IntroSectionLayout = styled.div`
-  display: flex;
-  flex-flow: column nowrap;
-  justify-content: center;
-  height: 100%;
 `;
 
 const infoTextWrapperStyle = css`


### PR DESCRIPTION
## 변경사항

- IntroSection에 잘못 적용된 padding을 IntroSectionLayout으로 이동

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
