### PR TITLE
SnapParent 컴포넌트의 overflow로 생기는 스크롤 UI를 숨김처리한다

### DIFF
--- a/apps/landing/src/components/common/SnapParent/SnapParent.styled.ts
+++ b/apps/landing/src/components/common/SnapParent/SnapParent.styled.ts
@@ -11,5 +11,11 @@ export const SnapParent = styled.div<SnapParentProps>`
     scroll-snap-type: ${axis} ${strictness};
     height: 100vh;
     overflow-y: scroll;
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+
+    &::-webkit-scrollbar {
+      display: none; /* Chrome, Safari, Opera*/
+    }
   `}
 `;

--- a/apps/landing/src/components/common/SnapParent/SnapParent.styled.ts
+++ b/apps/landing/src/components/common/SnapParent/SnapParent.styled.ts
@@ -10,6 +10,6 @@ export const SnapParent = styled.div<SnapParentProps>`
   ${({ axis = 'y', strictness = 'mandatory' }) => css`
     scroll-snap-type: ${axis} ${strictness};
     height: 100vh;
-    overflow: scroll;
+    overflow-y: scroll;
   `}
 `;


### PR DESCRIPTION
## 변경사항

- SnapParent의 스크롤 동작을 overflow-y에 한정
- SnapParent에 생기는 스크롤 UI를 숨김처리

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 리팩토링

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
