### PR TITLE
생일 축하 카드 리스트 기능 구현

### DIFF
--- a/apps/webview/app/birthday/card-list/Contents.tsx
+++ b/apps/webview/app/birthday/card-list/Contents.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import { type EmblaCarouselType } from 'embla-carousel';
+import useEmblaCarousel from 'embla-carousel-react';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { type BirthdayCardResponse } from '@/app/birthday/card-list/page';
+import useDownloadElementToImage from '@/app/birthday/hooks/useDownloadElementToImage';
+import { AspectRatio, Square, styled } from '@/styled-system/jsx';
+import SvgImage from '@/ui/svg-image';
+
+interface ContentsProps {
+  birthdayCards: BirthdayCardResponse[];
+}
+
+const Contents = ({ birthdayCards }: ContentsProps) => {
+  const router = useRouter();
+  const contentRefs = useRef<HTMLDivElement[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true });
+
+  const onSelect = useCallback((api: EmblaCarouselType) => {
+    setSelectedIndex(api.selectedScrollSnap());
+  }, []);
+
+  useEffect(() => {
+    if (!emblaApi) return;
+
+    onSelect(emblaApi);
+    emblaApi.on('select', onSelect);
+  }, [emblaApi, onSelect]);
+
+  const { saveImage } = useDownloadElementToImage(
+    { current: contentRefs.current[selectedIndex] },
+    'birthday_card.png',
+  );
+
+  const isEmptyBirthdayCards = birthdayCards.length === 0;
+
+  return (
+    <>
+      <styled.div ref={emblaRef} overflow="hidden">
+        <styled.div display="flex" ml="30px" maxW="calc(100% - 60px)">
+          {isEmptyBirthdayCards && (
+            <styled.div
+              ref={(birthdayCardRef) => {
+                contentRefs.current[selectedIndex] = birthdayCardRef!;
+              }}
+              bg="white"
+              w="calc(100%)"
+              flexShrink="0"
+              mr="20px"
+              rounded="32px"
+              p="24px"
+              display="flex"
+              flexDirection="column"
+              gap="24px"
+            >
+              <AspectRatio ratio={16 / 9} rounded="16px" overflow="hidden">
+                <Image
+                  unoptimized
+                  alt=""
+                  fill
+                  src="https://static.mash-up.kr/images/png/birthday/card-thumbnail-default.png"
+                />
+              </AspectRatio>
+              <styled.div display="flex" flexDirection="column" alignItems="center">
+                <styled.div display="flex" flexDirection="column" gap="4px" alignItems="center">
+                  <styled.span
+                    fontWeight={700}
+                    fontSize="24px"
+                    lineHeight={1.2}
+                    letterSpacing="-0.01em"
+                  >
+                    매숑이
+                  </styled.span>
+                  <styled.span
+                    fontSize="14px"
+                    fontWeight={400}
+                    lineHeight={1.2}
+                    letterSpacing="-0.01em"
+                    color="gray.500"
+                  >
+                    Mash-up
+                  </styled.span>
+                </styled.div>
+                <Square size="20px" />
+                <styled.span
+                  whiteSpace="pre-wrap"
+                  textAlign="center"
+                  fontWeight={400}
+                  fontSize="16px"
+                  lineHeight={1.2}
+                  letterSpacing="-0.01em"
+                  color="gray.800"
+                >
+                  {'생일 축하해🎉🎉🎉\n매쉬업에서 만나서 반가워!!\n좋은 하루 보내고 한잔해~'}
+                </styled.span>
+                <Square size="57px" />
+              </styled.div>
+            </styled.div>
+          )}
+          {birthdayCards.map((item, index) => (
+            <styled.div
+              ref={(birthdayCardRef) => {
+                contentRefs.current[index] = birthdayCardRef!;
+              }}
+              key={item.id}
+              bg="white"
+              w="calc(100%)"
+              flexShrink="0"
+              mr="20px"
+              rounded="32px"
+              p="24px"
+              display="flex"
+              flexDirection="column"
+              gap="24px"
+            >
+              <AspectRatio ratio={16 / 9} rounded="16px" overflow="hidden">
+                <Image
+                  unoptimized
+                  alt=""
+                  fill
+                  src={
+                    item.imageUrl ??
+                    'https://static.mash-up.kr/images/png/birthday/card-thumbnail-default.png'
+                  }
+                />
+              </AspectRatio>
+              <styled.div display="flex" flexDirection="column" alignItems="center">
+                <styled.div display="flex" flexDirection="column" gap="4px" alignItems="center">
+                  <styled.span
+                    fontWeight={700}
+                    fontSize="24px"
+                    lineHeight={1.2}
+                    letterSpacing="-0.01em"
+                  >
+                    {item.senderMemberName ?? '매숑이'}
+                  </styled.span>
+                  <styled.span
+                    fontSize="14px"
+                    fontWeight={400}
+                    lineHeight={1.2}
+                    letterSpacing="-0.01em"
+                    color="gray.500"
+                  >
+                    {item.senderMemberPlatform ?? 'Mash-up'}
+                  </styled.span>
+                </styled.div>
+                <Square size="20px" />
+                <styled.span
+                  whiteSpace="pre-wrap"
+                  textAlign="center"
+                  fontWeight={400}
+                  fontSize="16px"
+                  lineHeight={1.2}
+                  letterSpacing="-0.01em"
+                  color="gray.800"
+                >
+                  {item.message ??
+                    '생일 축하해!\n매쉬업에서 만날 수 있어서 좋았어\n오늘 즐거운 하루 보내'}
+                </styled.span>
+                <Square size="57px" />
+              </styled.div>
+            </styled.div>
+          ))}
+        </styled.div>
+      </styled.div>
+      <styled.div display="flex" flexDirection="column" gap="8px" px="16px">
+        <styled.button
+          bg="brand.100"
+          rounded="12px"
+          h="52px"
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          onClick={saveImage}
+        >
+          <styled.div display="flex" gap="8px">
+            <SvgImage
+              basePath="birthday"
+              path="card-list/download"
+              width={20}
+              height={20}
+              fill={false}
+            />
+            <styled.span
+              color="brand.500"
+              fontSize="16px"
+              lineHeight={1.2}
+              letterSpacing="-0.01em"
+              fontWeight={500}
+            >
+              이미지 저장
+            </styled.span>
+          </styled.div>
+        </styled.button>
+        <styled.button
+          bg="brand.500"
+          rounded="12px"
+          h="52px"
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          onClick={() => {
+            router.push('/birthday/crew-list');
+          }}
+        >
+          <styled.span
+            color="white"
+            fontSize="16px"
+            lineHeight={1.2}
+            letterSpacing="-0.01em"
+            fontWeight={500}
+          >
+            확인했어요
+          </styled.span>
+        </styled.button>
+      </styled.div>
+    </>
+  );
+};
+
+export default Contents;

--- a/apps/webview/app/birthday/card-list/Header.tsx
+++ b/apps/webview/app/birthday/card-list/Header.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { styled } from '@/styled-system/jsx';
+import SvgImage from '@/ui/svg-image';
+
+const Header = () => (
+  <styled.header
+    height="56px"
+    position="fixed"
+    maxW="[768px]"
+    w="100%"
+    left="[50%]"
+    translate="auto"
+    translateX="-1/2"
+    zIndex="1"
+  >
+    <styled.div
+      display="flex"
+      flexDirection="row"
+      justifyContent="end"
+      alignItems="center"
+      px="20px"
+      py="16px"
+    >
+      <SvgImage
+        basePath="birthday"
+        path="common/close"
+        width={24}
+        height={24}
+        fill={false}
+        onClick={() => {
+          // TODO: iOS, AOS 공통 브릿지 정의 예정
+          // @ts-ignore
+          window.webkit.messageHandlers.mashupBridge.postMessage({
+            step: 'back',
+          });
+        }}
+      />
+    </styled.div>
+  </styled.header>
+);
+
+export default Header;

--- a/apps/webview/app/birthday/card-list/layout.tsx
+++ b/apps/webview/app/birthday/card-list/layout.tsx
@@ -1,7 +1,27 @@
 import { type ReactNode } from 'react';
 
+import Header from '@/app/birthday/card-list/Header';
+import { styled } from '@/styled-system/jsx';
+
 export const metadata = {};
 
-const Layout = ({ children }: { children: ReactNode }) => <div>{children}</div>;
+const Layout = ({ children }: { children: ReactNode }) => (
+  <>
+    <Header />
+    <styled.div
+      bg="linear-gradient(162.61deg, #E2CBFF 10.57%, #A7E4FA 109.87%)"
+      display="flex"
+      flexDirection="column"
+      maxW="768px"
+      mx="auto"
+      minH="100dvh"
+      pt="56px"
+      pb="40px"
+      justifyContent="space-between"
+    >
+      {children}
+    </styled.div>
+  </>
+);
 
 export default Layout;

--- a/apps/webview/app/birthday/card-list/page.tsx
+++ b/apps/webview/app/birthday/card-list/page.tsx
@@ -1,3 +1,76 @@
-const Page = () => <div>Birthday Card List</div>;
+import { headers } from 'next/headers';
+import { notFound } from 'next/navigation';
+
+import Contents from '@/app/birthday/card-list/Contents';
+import { Square, styled } from '@/styled-system/jsx';
+
+export interface BirthdayCardResponse {
+  id: number;
+  imageUrl: string;
+  message: string;
+  senderMemberName: string;
+  senderMemberPlatform: string;
+}
+
+const getMyUsingGET = async ({
+  authorization,
+}: {
+  authorization: string;
+}): Promise<
+  | undefined
+  | {
+      data: {
+        birthdayCards: BirthdayCardResponse[];
+      };
+    }
+> => {
+  const getMyUsingGETResponse = await fetch(
+    'https://api.dev-member.mash-up.kr/api/v1/birthday-cards',
+    {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${authorization}`,
+      },
+    },
+  );
+  if (!getMyUsingGETResponse.ok) return undefined;
+  return getMyUsingGETResponse.json();
+};
+
+const Page = async () => {
+  const authorization = headers().get('authorization');
+
+  if (!authorization) {
+    notFound();
+  }
+
+  const getMyUsingGETData = await getMyUsingGET({ authorization });
+
+  if (!getMyUsingGETData) {
+    notFound();
+  }
+
+  return (
+    <>
+      <styled.div>
+        <styled.div px="20px">
+          <styled.h2
+            whiteSpace="pre-wrap"
+            fontWeight={700}
+            fontSize="24px"
+            lineHeight={1.2}
+            letterSpacing="-0.01em"
+          >
+            {getMyUsingGETData.data.birthdayCards.length === 0
+              ? '매숑이가 너에게만 보낸\n특별한 선물이야'
+              : '매숑이들이\n보낸 선물을 확인해 보세요'}
+          </styled.h2>
+        </styled.div>
+        <Square size="40px" />
+      </styled.div>
+      <Contents birthdayCards={getMyUsingGETData.data.birthdayCards} />
+    </>
+  );
+};
 
 export default Page;

--- a/apps/webview/app/birthday/hooks/useDownloadElementToImage.ts
+++ b/apps/webview/app/birthday/hooks/useDownloadElementToImage.ts
@@ -1,0 +1,45 @@
+import { toPng } from 'html-to-image';
+import { RefObject, useCallback } from 'react';
+
+import useWebShare from '@/app/birthday/hooks/useWebShare';
+
+const useDownloadElementToImage = <T extends HTMLElement>(ref: RefObject<T>, filename: string) => {
+  const { isSupported, share } = useWebShare();
+
+  const saveImage = useCallback(() => {
+    if (ref.current === null) {
+      return;
+    }
+
+    toPng(ref.current, {
+      cacheBust: true,
+      style: {
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+      },
+    })
+      .then(async (dataUrl) => {
+        if (isSupported) {
+          const response = await fetch(dataUrl);
+          const blob = await response.blob();
+          const file = new File([blob], filename, { type: blob.type });
+
+          share({ files: [file] });
+        } else {
+          const link = document.createElement('a');
+          link.download = filename;
+          link.href = dataUrl;
+
+          link.click();
+        }
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }, [ref, isSupported, filename, share]);
+
+  return { saveImage };
+};
+
+export default useDownloadElementToImage;

--- a/apps/webview/app/birthday/hooks/useWebShare/index.ts
+++ b/apps/webview/app/birthday/hooks/useWebShare/index.ts
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react';
+
+import { shareContent } from './shareContent';
+
+const noop: () => void = () => undefined;
+
+const useWebShare = (onSuccess = noop, onError = noop) => {
+  const [isSupported, setIsSupported] = useState(false);
+
+  useEffect(() => {
+    if (!navigator.share) {
+      setIsSupported(false);
+    } else {
+      setIsSupported(true);
+    }
+  }, [onSuccess, onError]);
+
+  return {
+    isSupported,
+    share: shareContent(onSuccess, onError),
+  };
+};
+
+export default useWebShare;

--- a/apps/webview/app/birthday/hooks/useWebShare/shareContent.ts
+++ b/apps/webview/app/birthday/hooks/useWebShare/shareContent.ts
@@ -1,0 +1,15 @@
+/* eslint-disable no-undef */
+/* eslint-disable no-unused-vars */
+export const shareContent =
+  (onSuccess: () => void, onError: (error?: unknown) => void) =>
+  ({ files, text, title, url }: ShareData = {}) => {
+    navigator
+      .share({ files, text, title, url })
+      .then(onSuccess)
+      .catch((error) => {
+        onError();
+        if (error.name === 'NotAllowedError') {
+          window.location.reload();
+        }
+      });
+  };

--- a/apps/webview/package.json
+++ b/apps/webview/package.json
@@ -18,7 +18,9 @@
     "react-dom": "18.3.1",
     "react-hot-toast": "^2.4.1",
     "ui": "*",
-    "usehooks-ts": "^3.1.0"
+    "usehooks-ts": "^3.1.0",
+    "embla-carousel-react": "8.1.6",
+    "html-to-image": "1.11.11"
   },
   "devDependencies": {
     "@pandacss/dev": "0.40.1",

--- a/apps/webview/panda.config.ts
+++ b/apps/webview/panda.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
         'gray.800': { value: '#383E4C' },
         'gray.900': { value: '#2C3037' },
         'red.100': { value: '#FFEBEE' },
+        'brand.100': { value: '#F5F1FF' },
         'brand.200': { value: '#E7DEFF' },
         'brand.300': { value: '#CDBFF6' },
         'brand.500': { value: '#6A36FF' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3186,6 +3186,24 @@ electron-to-chromium@^1.4.668, electron-to-chromium@^1.4.796:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.814.tgz#176535a0b899c9c473464502ab77576aa8bb1cbe"
   integrity sha512-GVulpHjFu1Y9ZvikvbArHmAhZXtm3wHlpjTMcXNGKl4IQ4jMQjlnz8yMQYYqdLHKi/jEL2+CBC2akWVCoIGUdw==
 
+embla-carousel-react@8.1.6:
+  version "8.1.6"
+  resolved "https://registry.yarnpkg.com/embla-carousel-react/-/embla-carousel-react-8.1.6.tgz#4de0cef2888443f4203408df73af2707e5c961e9"
+  integrity sha512-DHxwFzF63yVrU95Eo58E9Xr5b6Y9ul6TTsqb/rtwMi+jXudAmIqN1i9iBxQ73i8jKuUVxll/ziNYMmnWvrdQJQ==
+  dependencies:
+    embla-carousel "8.1.6"
+    embla-carousel-reactive-utils "8.1.6"
+
+embla-carousel-reactive-utils@8.1.6:
+  version "8.1.6"
+  resolved "https://registry.yarnpkg.com/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.1.6.tgz#51c4a1dc6df1e608e9480f7a5fc3328e95926f91"
+  integrity sha512-Wg+J2YoqLqkaqsXi7fTJaLmXm6BpgDRJ0EfTdvQ4KE/ip5OsUuKGpJsEQDTt4waGXSDyZhIBlfoQtgGJeyYQ1Q==
+
+embla-carousel@8.1.6:
+  version "8.1.6"
+  resolved "https://registry.yarnpkg.com/embla-carousel/-/embla-carousel-8.1.6.tgz#a67f0b51f0cb51131299c47dff18e2d08165d44a"
+  integrity sha512-9n7FVsbPAs1KD+JmO84DnEDOZMXPBQbLujjMQqvsBRN2CDWwgZ9hRSNapztdPnyJfzOIxowGmj0BUQ8ACYAPkA==
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -4343,6 +4361,11 @@ html-tags@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.3.1.tgz#a04026a18c882e4bba8a01a3d39cfe465d40b5ce"
   integrity sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==
+
+html-to-image@1.11.11:
+  version "1.11.11"
+  resolved "https://registry.yarnpkg.com/html-to-image/-/html-to-image-1.11.11.tgz#c0f8a34dc9e4b97b93ff7ea286eb8562642ebbea"
+  integrity sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA==
 
 htmlparser2@^3.10.0:
   version "3.10.1"


### PR DESCRIPTION
## 변경사항
<img width="802" alt="image" src="https://github.com/user-attachments/assets/92b75bfc-f464-45f2-98fd-70db39adec08">

- 전달받은 생일 축하 카드가 하나도 없는 경우 (Empty) 구현
- 전달받은 생일 축하 카드 리스트가 여러 개 있는 경우 구현
- Swipable Carousel을 구현하기 위해 [embla-carousel](https://www.embla-carousel.com/)을 설치하였음.
- 이미지 다운로드 기능 구현을 위해 html-to-image를 설치하였음.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 패키지 추가 및 버전 변경

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
