### PR TITLE
웹뷰(iOS, AOS) 핸들러 정의

### DIFF
--- a/apps/webview/app/birthday/card-list/Header.tsx
+++ b/apps/webview/app/birthday/card-list/Header.tsx
@@ -1,43 +1,44 @@
 'use client';
 
+import { useWebviewHandler } from '@/hooks/useWebviewHandler';
 import { styled } from '@/styled-system/jsx';
 import SvgImage from '@/ui/svg-image';
 
-const Header = () => (
-  <styled.header
-    height="56px"
-    position="fixed"
-    maxW="[768px]"
-    w="100%"
-    left="[50%]"
-    translate="auto"
-    translateX="-1/2"
-    zIndex="1"
-  >
-    <styled.div
-      display="flex"
-      flexDirection="row"
-      justifyContent="end"
-      alignItems="center"
-      px="20px"
-      py="16px"
+const Header = () => {
+  const webviewHandler = useWebviewHandler();
+
+  return (
+    <styled.header
+      height="56px"
+      position="fixed"
+      maxW="[768px]"
+      w="100%"
+      left="[50%]"
+      translate="auto"
+      translateX="-1/2"
+      zIndex="1"
     >
-      <SvgImage
-        basePath="birthday"
-        path="common/close"
-        width={24}
-        height={24}
-        fill={false}
-        onClick={() => {
-          // TODO: iOS, AOS 공통 브릿지 정의 예정
-          // @ts-ignore
-          window.webkit.messageHandlers.mashupBridge.postMessage({
-            step: 'back',
-          });
-        }}
-      />
-    </styled.div>
-  </styled.header>
-);
+      <styled.div
+        display="flex"
+        flexDirection="row"
+        justifyContent="end"
+        alignItems="center"
+        px="20px"
+        py="16px"
+      >
+        <SvgImage
+          basePath="birthday"
+          path="common/close"
+          width={24}
+          height={24}
+          fill={false}
+          onClick={() => {
+            webviewHandler.step('back');
+          }}
+        />
+      </styled.div>
+    </styled.header>
+  );
+};
 
 export default Header;

--- a/apps/webview/app/mashong/mission-board/Header.tsx
+++ b/apps/webview/app/mashong/mission-board/Header.tsx
@@ -1,74 +1,71 @@
 'use client';
 
+import { useWebviewHandler } from '@/hooks/useWebviewHandler';
 import { styled } from '@/styled-system/jsx';
 import SvgImage from '@/ui/svg-image';
 
-const Header = () => (
-  <styled.header
-    height="[56px]"
-    position="fixed"
-    maxW="[768px]"
-    w="100%"
-    left="[50%]"
-    translate="auto"
-    translateX="-1/2"
-    bg="[#6A36FF]"
-    zIndex="1"
-  >
-    <styled.div
-      display="flex"
-      flexDirection="row"
-      justifyContent="space-between"
-      alignItems="center"
-      h="full"
-      p="[8px]"
+const Header = () => {
+  const webviewHandler = useWebviewHandler();
+
+  return (
+    <styled.header
+      height="[56px]"
+      position="fixed"
+      maxW="[768px]"
+      w="100%"
+      left="[50%]"
+      translate="auto"
+      translateX="-1/2"
+      bg="[#6A36FF]"
+      zIndex="1"
     >
-      <SvgImage
-        path="mission-board/chevron-left"
-        width={40}
-        height={40}
-        fill={false}
-        onClick={() => {
-          // TODO: iOS, AOS 공통 브릿지 정의 예정
-          // @ts-ignore
-          window.webkit.messageHandlers.mashupBridge.postMessage({
-            step: 'back',
-          });
-        }}
-      />
-      <styled.h1
-        fontSize="16px"
-        lineHeight="1.2"
-        letterSpacing="-0.01em"
-        fontWeight="600"
-        color="white"
-      >
-        미션
-      </styled.h1>
       <styled.div
         display="flex"
         flexDirection="row"
-        w="40px"
-        h="40px"
-        justifyContent="center"
+        justifyContent="space-between"
         alignItems="center"
+        h="full"
+        p="[8px]"
       >
         <SvgImage
-          path="mission-board/carrot"
-          width={32}
-          height={32}
+          path="mission-board/chevron-left"
+          width={40}
+          height={40}
           fill={false}
           onClick={() => {
-            // TODO: iOS, AOS 공통 브릿지 정의 예정
-            // @ts-ignore
-            window.webkit.messageHandlers.mashupBridge.postMessage({
-              step: 'danggn',
-            });
+            webviewHandler.step('back');
           }}
         />
+        <styled.h1
+          fontSize="16px"
+          lineHeight="1.2"
+          letterSpacing="-0.01em"
+          fontWeight="600"
+          color="white"
+        >
+          미션
+        </styled.h1>
+        <styled.div
+          display="flex"
+          flexDirection="row"
+          w="40px"
+          h="40px"
+          justifyContent="center"
+          alignItems="center"
+        >
+          <SvgImage
+            path="mission-board/carrot"
+            width={32}
+            height={32}
+            fill={false}
+            onClick={() => {
+              webviewHandler.step('danggn');
+            }}
+          />
+        </styled.div>
       </styled.div>
-    </styled.div>
-  </styled.header>
-);
+    </styled.header>
+  );
+};
 
 export default Header;

--- a/apps/webview/global.d.ts
+++ b/apps/webview/global.d.ts
@@ -1,0 +1,15 @@
+export declare global {
+  // eslint-disable-next-line no-unused-vars
+  interface Window {
+    MashupBridge: {
+      step: Function;
+    };
+    webkit: {
+      messageHandlers: {
+        mashupBridge: {
+          postMessage: Function;
+        };
+      };
+    };
+  }
+}

--- a/apps/webview/hooks/useWebviewHandler.ts
+++ b/apps/webview/hooks/useWebviewHandler.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+
+import { AndroidBridge, AppleBridge, WebviewHandler } from '@/lib/WebviewHandler';
+
+const isDom = () => typeof window !== 'undefined';
+function getPlatform() {
+  const agent = (navigator as any).userAgentData;
+  return agent?.platform ?? navigator.platform;
+}
+
+const pt = (v: RegExp) => isDom() && v.test(getPlatform());
+const ua = (v: RegExp) => isDom() && v.test(navigator.userAgent);
+
+const isApple = () => pt(/mac|iphone|ipad|ipod/i);
+const isAndroid = () => pt(/android/i) || ua(/android/i);
+
+type Handler = InstanceType<typeof WebviewHandler>;
+
+export const useWebviewHandler = () => {
+  const [handler, setHandler] = useState<Handler | null>(null);
+
+  useEffect(() => {
+    if (handler) return;
+
+    if (isApple()) {
+      setHandler(new WebviewHandler(new AppleBridge()));
+    } else if (isAndroid()) {
+      setHandler(new WebviewHandler(new AndroidBridge()));
+    }
+  }, []);
+
+  return handler ?? { step: () => {} };
+};

--- a/apps/webview/lib/WebviewHandler.ts
+++ b/apps/webview/lib/WebviewHandler.ts
@@ -1,0 +1,33 @@
+/* eslint-disable class-methods-use-this */
+/* eslint-disable max-classes-per-file */
+type StepTarget = ['danggn', 'back'][number];
+
+interface BridgeImplementer {
+  // eslint-disable-next-line no-unused-vars
+  step: (target: StepTarget) => void;
+}
+
+export class AndroidBridge implements BridgeImplementer {
+  step(target: StepTarget) {
+    window.MashupBridge.step(target);
+  }
+}
+export class AppleBridge implements BridgeImplementer {
+  step(target: StepTarget) {
+    window.webkit.messageHandlers.mashupBridge.postMessage({
+      step: target,
+    });
+  }
+}
+
+export class WebviewHandler {
+  protected bridge: BridgeImplementer;
+
+  constructor(bridge: BridgeImplementer) {
+    this.bridge = bridge;
+  }
+
+  step(target: StepTarget) {
+    this.bridge.step(target);
+  }
+}


### PR DESCRIPTION
## 변경사항

- 사용하는 곳에서는 일관된 API로 사용하고, useWebviewHandler라는 커스텀 훅 내에서 현재 platform 별로 분기하여 필요한 브릿지를 주입합니다.
- 현재는 뒤로가기(back)와 당근(danggn)에 대한 페이지 값만 정의하였고, 필요한 경우 해당 타입을 확장하면 됩니다!

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
