### PR TITLE
미션 보드 내 팝콘 수령 기능 추가

### DIFF
--- a/apps/webview/app/_actions/compensatePopcorn.ts
+++ b/apps/webview/app/_actions/compensatePopcorn.ts
@@ -1,0 +1,37 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { cookies } from 'next/headers';
+
+export const compensatePopcorn = async ({ missionLevelId }: { missionLevelId: number }) => {
+  try {
+    const authToken = cookies().get('token');
+
+    if (!authToken) {
+      throw new Error(`유효한 인증 토큰이 필요합니다.`);
+    }
+
+    const params = new URLSearchParams({
+      missionLevelId: String(missionLevelId),
+    });
+
+    const res = await fetch(
+      `https://api.dev-member.mash-up.kr/api/v1/mashong/popcorn?${params.toString()}`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${authToken.value}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    revalidatePath('mashong-mission-status');
+
+    const { data } = await res.json();
+    return data as boolean;
+  } catch (error) {
+    console.error(error);
+    return false;
+  }
+};

--- a/apps/webview/app/mashong/mission-board/Popup.tsx
+++ b/apps/webview/app/mashong/mission-board/Popup.tsx
@@ -1,11 +1,19 @@
+/* eslint-disable no-unused-vars */
 import { ElementRef, useRef } from 'react';
 import { useOnClickOutside } from 'usehooks-ts';
 
 import { styled } from '@/styled-system/jsx';
 import SvgImage from '@/ui/svg-image';
 
-// eslint-disable-next-line no-unused-vars
-const Popup = ({ isOpen, setIsOpen }: { isOpen: boolean; setIsOpen: (value: boolean) => void }) => {
+const Popup = ({
+  isOpen,
+  setIsOpen,
+  popupData,
+}: {
+  isOpen: boolean;
+  setIsOpen: (value: boolean) => void;
+  popupData: number;
+}) => {
   const contentsRef = useRef<ElementRef<typeof styled.div>>(null);
 
   const handleClickContentsOutside = () => {
@@ -49,7 +57,7 @@ const Popup = ({ isOpen, setIsOpen }: { isOpen: boolean; setIsOpen: (value: bool
             fontSize="20px"
             letterSpacing="-0.01em"
           >
-            매숑이에게 먹일{'\n'}팝콘 3알을 획득하셨어요!
+            매숑이에게 먹일{'\n'}팝콘 {popupData}알을 획득하셨어요!
           </styled.p>
           <styled.button
             rounded="12px"

--- a/apps/webview/app/mashong/mission-board/layout.tsx
+++ b/apps/webview/app/mashong/mission-board/layout.tsx
@@ -12,12 +12,9 @@ const Layout = ({ children }: { children: ReactNode }) => (
       maxWidth="[768px]"
       mx="auto"
       minH="100dvh"
-      pt="56px"
-      pb="[env(safe-area-inset-bottom)]"
+      pb="env(safe-area-inset-bottom)"
       bg="[#6A36FF]"
-      style={{
-        paddingTop: 'calc(56px + env(safe-area-inset-top))',
-      }}
+      pt="calc(56px + env(safe-area-inset-top))"
     >
       {children}
     </styled.div>

--- a/apps/webview/app/mashong/mission-board/page.tsx
+++ b/apps/webview/app/mashong/mission-board/page.tsx
@@ -1,4 +1,4 @@
-import { headers } from 'next/headers';
+import { cookies, headers } from 'next/headers';
 import { notFound } from 'next/navigation';
 
 import Sheet from '@/app/mashong/mission-board/Sheet';
@@ -29,6 +29,7 @@ const missionStatusListUsingGET = async ({
       headers: {
         Authorization: `Bearer ${authorization}`,
       },
+      next: { tags: ['mashong-mission-status'] },
     },
   );
 
@@ -37,7 +38,7 @@ const missionStatusListUsingGET = async ({
 };
 
 const Page = async () => {
-  const authorization = headers().get('authorization');
+  const authorization = cookies().get('token')?.value ?? headers().get('authorization');
 
   if (!authorization) {
     notFound();


### PR DESCRIPTION
## 변경사항

- 미션 보드 내에서 팝콘 수령 기능을 추가하고, 결과 UI를 추가합니다.
- 팝콘 수령 후 팝업 노출 및 page 레벨에서 fetch API의 revalidatePath ('mashong-mission-status')를 수행합니다.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/8adcc65a-1860-437e-b2ef-046319e65a1b">

<img width="300" alt="image" src="https://github.com/user-attachments/assets/2970004d-5546-471b-8885-620ade90e216">


### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
