### PR TITLE
iOS 웹뷰 / safe-area-inset 적용

### DIFF
--- a/apps/webview/app/birthday/card-list/Header.tsx
+++ b/apps/webview/app/birthday/card-list/Header.tsx
@@ -9,7 +9,8 @@ const Header = () => {
 
   return (
     <styled.header
-      height="56px"
+      height="calc(env(safe-area-inset-top) + 56px)"
+      pt="env(safe-area-inset-top)"
       position="fixed"
       maxW="[768px]"
       w="100%"

--- a/apps/webview/app/birthday/card-list/page.tsx
+++ b/apps/webview/app/birthday/card-list/page.tsx
@@ -53,7 +53,7 @@ const Page = async () => {
   return (
     <>
       <styled.div>
-        <styled.div px="20px">
+        <styled.div px="20px" pt="env(safe-area-inset-top)">
           <styled.h2
             whiteSpace="pre-wrap"
             fontWeight={700}

--- a/apps/webview/app/birthday/crew-list/layout.tsx
+++ b/apps/webview/app/birthday/crew-list/layout.tsx
@@ -1,7 +1,13 @@
 import { type ReactNode } from 'react';
 
+import { styled } from '@/styled-system/jsx';
+
 export const metadata = {};
 
-const Layout = ({ children }: { children: ReactNode }) => <div>{children}</div>;
+const Layout = ({ children }: { children: ReactNode }) => (
+  <styled.div bgColor="gray.50" width="100%" height="100%">
+    {children}
+  </styled.div>
+);
 
 export default Layout;

--- a/apps/webview/app/birthday/crew-list/page.tsx
+++ b/apps/webview/app/birthday/crew-list/page.tsx
@@ -42,13 +42,15 @@ const Page = () => {
   }, [data]);
 
   return (
-    <styled.div bgColor="#F8F7FC" width="100%" height="100%">
+    <>
       <styled.div
-        height="56px"
-        position="sticky"
-        top="0px"
-        bgColor="#F8F7FC"
-        p="8px"
+        position="fixed"
+        bgColor="gray.50"
+        display="flex"
+        alignItems="center"
+        height="calc(env(safe-area-inset-top) + 56px)"
+        pt="env(safe-area-inset-top)"
+        minW="100%"
         onClick={() => {
           webviewHandler.step('back');
         }}
@@ -63,9 +65,9 @@ const Page = () => {
           <path
             d="M23 13L16 20L23 27"
             stroke="#383E4C"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
           />
         </svg>
       </styled.div>
@@ -111,7 +113,13 @@ const Page = () => {
       )}
       <styled.div
         p="0 20px 20px"
-        height={data?.isBirthdayToday ? 'calc(100vh - 178px)' : 'calc(100vh - 56px)'}
+        bgColor="gray.50"
+        pt={
+          data?.isBirthdayToday
+            ? 'calc(178px + env(safe-area-inset-top))'
+            : 'calc(56px + env(safe-area-inset-top))'
+        }
+        height="100dvh"
         overflow="auto"
       >
         <styled.div display="flex" gap="32px" flexDirection="column">
@@ -282,7 +290,7 @@ const Page = () => {
           </styled.button>
         </styled.div>
       </BottomSheet>
-    </styled.div>
+    </>
   );
 };
 export default Page;

--- a/apps/webview/app/layout.tsx
+++ b/apps/webview/app/layout.tsx
@@ -1,3 +1,4 @@
+import { type Viewport } from 'next';
 import localFont from 'next/font/local';
 import '@/index.css';
 import { type ReactNode } from 'react';
@@ -9,6 +10,11 @@ const pretendard = localFont({
   display: 'swap',
   weight: '45 920',
 });
+
+export const viewport: Viewport = {
+  initialScale: 1.0,
+  viewportFit: 'cover',
+};
 
 const RootLayout = ({
   // Layouts must accept a children prop.

--- a/apps/webview/app/mashong/[team]/layout.tsx
+++ b/apps/webview/app/mashong/[team]/layout.tsx
@@ -11,13 +11,10 @@ const Layout = ({ children }: { children: ReactNode }) => (
     maxWidth="[768px]"
     mx="auto"
     minH="100dvh"
-    pt="56px"
-    pb="[env(safe-area-inset-bottom)]"
+    pt="env(safe-area-inset-top)"
+    pb="env(safe-area-inset-bottom)"
     px={24}
     backgroundColor="gray.50"
-    style={{
-      paddingTop: 'calc(56px + env(safe-area-inset-top))',
-    }}
   >
     {children}
   </styled.div>

--- a/apps/webview/app/mashong/[team]/page.tsx
+++ b/apps/webview/app/mashong/[team]/page.tsx
@@ -69,7 +69,7 @@ const Page = async ({ params }: { params: { team: string } }) => {
 
   return (
     <styled.div>
-      <styled.div display="flex" justifyContent="space-between">
+      <styled.div display="flex" justifyContent="space-between" my="8px">
         <TopNavigationButton />
         <GoDiaryButton />
       </styled.div>

--- a/apps/webview/app/mashong/mission-board/Header.tsx
+++ b/apps/webview/app/mashong/mission-board/Header.tsx
@@ -9,7 +9,7 @@ const Header = () => {
 
   return (
     <styled.header
-      height="[56px]"
+      height="calc(env(safe-area-inset-top) + 56px)"
       position="fixed"
       maxW="[768px]"
       w="100%"
@@ -17,6 +17,7 @@ const Header = () => {
       translate="auto"
       translateX="-1/2"
       bg="[#6A36FF]"
+      pt="env(safe-area-inset-top)"
       zIndex="1"
     >
       <styled.div

--- a/apps/webview/app/mashong/mission-board/Popup.tsx
+++ b/apps/webview/app/mashong/mission-board/Popup.tsx
@@ -22,65 +22,65 @@ const Popup = ({
 
   useOnClickOutside(contentsRef, handleClickContentsOutside);
 
+  if (!isOpen) return null;
+
   return (
-    isOpen && (
+    <styled.div
+      w="100%"
+      h="100%"
+      position="fixed"
+      top="0"
+      bg="rgba(0, 0, 0, 0.8)"
+      zIndex="100"
+      maxW="768px"
+      left="50%"
+      translate="auto"
+      translateX="-1/2"
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+    >
       <styled.div
-        w="100%"
-        h="100%"
-        position="fixed"
-        top="0"
-        bg="rgba(0, 0, 0, 0.8)"
-        zIndex="100"
-        maxW="768px"
-        left="50%"
-        translate="auto"
-        translateX="-1/2"
+        ref={contentsRef}
         display="flex"
+        flexDirection="column"
+        gap="26px"
         justifyContent="center"
         alignItems="center"
       >
-        <styled.div
-          ref={contentsRef}
-          display="flex"
-          flexDirection="column"
-          gap="26px"
-          justifyContent="center"
-          alignItems="center"
+        <SvgImage path="mission-board/eat-popcorn" width={200} height={140} />
+        <styled.p
+          whiteSpace="pre-wrap"
+          textAlign="center"
+          color="rgba(255, 255, 255, 1)"
+          fontWeight={600}
+          lineHeight="24px"
+          fontSize="20px"
+          letterSpacing="-0.01em"
         >
-          <SvgImage path="mission-board/eat-popcorn" width={200} height={140} />
-          <styled.p
-            whiteSpace="pre-wrap"
-            textAlign="center"
-            color="rgba(255, 255, 255, 1)"
-            fontWeight={600}
-            lineHeight="24px"
-            fontSize="20px"
+          매숑이에게 먹일{'\n'}팝콘 {popupData}알을 획득하셨어요!
+        </styled.p>
+        <styled.button
+          rounded="12px"
+          w="120px"
+          h="52px"
+          bg="rgba(106,54,255,1)"
+          onClick={() => {
+            setIsOpen(false);
+          }}
+        >
+          <styled.span
+            fontSize="16px"
+            lineHeight="1.2"
             letterSpacing="-0.01em"
+            fontWeight={500}
+            color="rgba(255,255,255,1)"
           >
-            매숑이에게 먹일{'\n'}팝콘 {popupData}알을 획득하셨어요!
-          </styled.p>
-          <styled.button
-            rounded="12px"
-            w="120px"
-            h="52px"
-            bg="rgba(106,54,255,1)"
-            onClick={() => {
-              setIsOpen(false);
-            }}
-          >
-            <styled.span
-              fontSize="16px"
-              lineHeight="1.2"
-              letterSpacing="-0.01em"
-              fontWeight={500}
-              color="rgba(255,255,255,1)"
-            >
-              확인
-            </styled.span>
-          </styled.button>
-        </styled.div>
+            확인
+          </styled.span>
+        </styled.button>
       </styled.div>
-    )
+    </styled.div>
   );
 };
 

--- a/apps/webview/app/mashong/mission-board/Sheet.tsx
+++ b/apps/webview/app/mashong/mission-board/Sheet.tsx
@@ -369,7 +369,7 @@ const Sheet = ({ missions }: { missions: MissionStatus[] }) => {
         w="100%"
         maxW="768px"
         position="fixed"
-        top="206"
+        top="calc(56px + env(safe-area-inset-top) + 150px)"
         dragElastic={0}
         dragMomentum={false}
       >


### PR DESCRIPTION
## 변경사항

- iOS 앱 내 웹뷰로 랜딩될 시에 상단의 safe-area만큼 떨어질 수 있도록 스타일을 수정하였습니다.
- 웹뷰 영역 자체가 스크롤되지 않게 하기 위해 모든 페이지를 body 스크롤로 변경하고, body 태그의 overflow나 배경 색상을 정의할 수 있도록 커스텀 훅을 정의해야 합니다 (useBodyClass) / 해당 작업은 별도 PR로 진행하겠습니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
