### PR TITLE
생일축하 / Middleware Matcher 추가 정의

### DIFF
--- a/apps/webview/app/mashong/[team]/_components/TopMenuButton.tsx
+++ b/apps/webview/app/mashong/[team]/_components/TopMenuButton.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { PropsWithChildren, useState } from 'react';
 
 import { css } from '@/styled-system/css';
@@ -12,13 +13,14 @@ export const TopMenuButton = ({
   variant,
   children,
 }: PropsWithChildren<{ variant: 'checkin' | 'mission' }>) => {
+  const router = useRouter();
   const [isSheetOpen, setIsSheetOpen] = useState(false);
 
   const onClick = () => {
     if (variant === 'checkin') {
       setIsSheetOpen(true);
     } else {
-      // TODO: mission route
+      router.push('/mashong/mission-board');
     }
   };
 

--- a/apps/webview/middleware.ts
+++ b/apps/webview/middleware.ts
@@ -19,5 +19,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: '/mashong/:path*',
+  matcher: ['/mashong/:path*', '/birthday/:path*'],
 };


### PR DESCRIPTION
## 변경사항

- Next.js middleware가 동작할 대상 path에 생일 축하(/birthday/*) 경로를 추가합니다.
- 매숑이 키우기 메인 페이지 내 미션 리스트 라우팅 로직이 누락되어 있어 함께 추가합니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
