### PR TITLE
미션 페이지의 visibility 변경 시 refetch 수행

### DIFF
--- a/apps/webview/app/mashong/mission-board/Sheet.tsx
+++ b/apps/webview/app/mashong/mission-board/Sheet.tsx
@@ -3,8 +3,9 @@
 'use client';
 
 import { motion, useMotionValue, useMotionValueEvent, useScroll } from 'framer-motion';
+import { useRouter } from 'next/navigation';
 import { ElementRef, useEffect, useRef, useState } from 'react';
-import { useScrollLock } from 'usehooks-ts';
+import { useEventListener } from 'usehooks-ts';
 
 import { compensatePopcorn } from '@/app/_actions/compensatePopcorn';
 import { MissionStatus } from '@/app/mashong/mission-board/page';
@@ -321,7 +322,22 @@ const IndividualMissions = ({
 );
 
 const Sheet = ({ missions }: { missions: MissionStatus[] }) => {
-  useScrollLock();
+  const router = useRouter();
+
+  const documentRef = useRef<Document | null>(null);
+
+  useEffect(() => {
+    documentRef.current = document;
+  }, []);
+
+  useEventListener(
+    'visibilitychange',
+    () => {
+      if (document.hidden) return;
+      router.refresh();
+    },
+    documentRef,
+  );
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [popupData, setPopupData] = useState(0);
   const y = useMotionValue(0);


### PR DESCRIPTION
## 변경사항

- 미션 페이지 내에서 당근 흔들기 진입 후 다시 돌아왔을 때 변경된 상태를 반영하기 위해 document의 visibility의 변경 이벤트를 감지 -> visibility !== hidden인 경우에 refetch를 수행합니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
