### PR TITLE
팝콘 주기 동작 수정

### DIFF
--- a/apps/webview/app/_actions/compensatePopcorn.ts
+++ b/apps/webview/app/_actions/compensatePopcorn.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { revalidatePath } from 'next/cache';
+import { revalidateTag } from 'next/cache';
 import { cookies } from 'next/headers';
 
 export const compensatePopcorn = async ({ missionLevelId }: { missionLevelId: number }) => {
@@ -26,7 +26,7 @@ export const compensatePopcorn = async ({ missionLevelId }: { missionLevelId: nu
       },
     );
 
-    revalidatePath('mashong-mission-status');
+    revalidateTag('mashong-mission-status');
 
     const { data } = await res.json();
     return data as boolean;

--- a/apps/webview/app/_actions/feedPopcorn.ts
+++ b/apps/webview/app/_actions/feedPopcorn.ts
@@ -1,6 +1,5 @@
 'use server';
 
-import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 
 export const feedPopcorn = async () => {
@@ -21,8 +20,6 @@ export const feedPopcorn = async () => {
         popcornCount: 1,
       }),
     });
-
-    revalidatePath('mashong-status');
 
     const { data } = await res.json();
     return data;

--- a/apps/webview/app/_actions/levelUp.ts
+++ b/apps/webview/app/_actions/levelUp.ts
@@ -1,6 +1,5 @@
 'use server';
 
-import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 
 export const levelUp = async (goalLevel: number) => {
@@ -21,8 +20,6 @@ export const levelUp = async (goalLevel: number) => {
         goalLevel,
       }),
     });
-
-    revalidatePath('mashong-status');
 
     const { data } = await res.json();
     return data;

--- a/apps/webview/app/mashong/[team]/_components/MashongRoomContainer.tsx
+++ b/apps/webview/app/mashong/[team]/_components/MashongRoomContainer.tsx
@@ -45,7 +45,7 @@ export const MashongRoomContainer = ({
 
           setTimeout(() => {
             setIsFeeding(false);
-          }, 200);
+          }, 1000);
         }}
       />
       <Toast />

--- a/apps/webview/app/mashong/[team]/_components/PopcornXpTracker.tsx
+++ b/apps/webview/app/mashong/[team]/_components/PopcornXpTracker.tsx
@@ -37,7 +37,7 @@ export const PopcornXpTracker = ({
 
   const remainingXP = maxXP - localXP;
 
-  const levelUpAvailable = Boolean(remainingXP === 0 && Cookies.get('token'));
+  const levelUpAvailable = Boolean(remainingXP <= 0 && Cookies.get('token'));
 
   return (
     <div
@@ -90,7 +90,7 @@ export const PopcornXpTracker = ({
             color: 'gray.500',
           })}
         >
-          {remainingXP}점 남음
+          {remainingXP >= 0 ? remainingXP : 0}점 남음
         </span>
       </div>
       <progress

--- a/apps/webview/app/mashong/[team]/_components/PopcornXpTracker.tsx
+++ b/apps/webview/app/mashong/[team]/_components/PopcornXpTracker.tsx
@@ -124,8 +124,6 @@ export const PopcornXpTracker = ({
             router.push('/mashong/mission-board');
             Cookies.set('popcornAlertSeen', '1');
           } else if (localXP < maxXP) {
-            onClick();
-
             try {
               await feedPopcorn();
 
@@ -136,6 +134,7 @@ export const PopcornXpTracker = ({
               setCurrentFeedingPopcorn((prev) => prev + 1);
               setLocalXP((prevXP) => Math.min(prevXP + 1, maxXP));
               setAvailablePopcorn((prev) => prev - 1);
+              onClick();
             } catch (error) {
               showErrorToast('팝콘 주기를 실패했어요..');
             }


### PR DESCRIPTION
## 변경사항

https://github.com/user-attachments/assets/08e4046d-684c-4272-9388-29ce08ffdf76

- feed에서 revalidateTag 제거
- 팝콘 주기 간격 1초로 제한
- 팝콘 주기 실패시 말풍선 노출되지 않도록 수정

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 버그 수정


### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
