### PR TITLE
수령 가능 팝콘 갯수 로직 수정

### DIFF
--- a/apps/webview/app/mashong/mission-board/page.tsx
+++ b/apps/webview/app/mashong/mission-board/page.tsx
@@ -55,7 +55,7 @@ const Page = async () => {
   }
 
   const popcornCountRemainingToObtain = missionStatusListUsingGETData.data.reduce(
-    (acc, datum) => acc + datum.compensation,
+    (acc, { isCompensated, compensation }) => (isCompensated ? acc : acc + compensation),
     0,
   );
 


### PR DESCRIPTION
## 변경사항

- 이미 보상 수령한 미션에 대해서는 수령 가능한 팝콘 갯수에 포함되지 않도록 로직을 수정합니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
