### PR TITLE
미션 상태 API polling 적용

### DIFF
--- a/apps/webview/app/mashong/_actions/revalidateMashongMissionStatus.ts
+++ b/apps/webview/app/mashong/_actions/revalidateMashongMissionStatus.ts
@@ -1,0 +1,11 @@
+'use server';
+
+import { revalidateTag } from 'next/cache';
+
+export const revalidateMashongMissionStatus = async () => {
+  try {
+    revalidateTag('mashong-mission-status');
+  } catch (error) {
+    console.error('revalidateMashongMissionStatus', error);
+  }
+};

--- a/apps/webview/app/mashong/mission-board/Sheet.tsx
+++ b/apps/webview/app/mashong/mission-board/Sheet.tsx
@@ -5,9 +5,10 @@
 import { motion, useMotionValue, useMotionValueEvent, useScroll } from 'framer-motion';
 import { useRouter } from 'next/navigation';
 import { ElementRef, useEffect, useRef, useState } from 'react';
-import { useEventListener } from 'usehooks-ts';
+import { useInterval } from 'usehooks-ts';
 
 import { compensatePopcorn } from '@/app/mashong/_actions/compensatePopcorn';
+import { revalidateMashongMissionStatus } from '@/app/mashong/_actions/revalidateMashongMissionStatus';
 import { MissionStatus } from '@/app/mashong/mission-board/page';
 import Popup from '@/app/mashong/mission-board/Popup';
 import { Square, styled } from '@/styled-system/jsx';
@@ -322,22 +323,10 @@ const IndividualMissions = ({
 );
 
 const Sheet = ({ missions }: { missions: MissionStatus[] }) => {
-  const router = useRouter();
+  useInterval(() => {
+    revalidateMashongMissionStatus();
+  }, 2000);
 
-  const documentRef = useRef<Document | null>(null);
-
-  useEffect(() => {
-    documentRef.current = document;
-  }, []);
-
-  useEventListener(
-    'visibilitychange',
-    () => {
-      if (document.hidden) return;
-      router.refresh();
-    },
-    documentRef,
-  );
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [popupData, setPopupData] = useState(0);
   const y = useMotionValue(0);


### PR DESCRIPTION
## 변경사항

- AOS에서 visiblitychange 이벤트가 제대로 감지되지 않음. 추가로 기존에는 개인이 수행한 미션에 대해서만 revalidate를 수행할 수 있었음.
- 개인이 수행한 미션 외에도 팀이 수행한 미션 역시 반영할 수 있도록 미션 상태 API를 주기적으로 revalidate하는 polling 방식을 도입합니다.

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
