### PR TITLE
랜딩페이지 푸터의 외부링크 순서를 14기 시점 노출 우선순위에 따라 변경

### DIFF
--- a/apps/landing/src/components/common/Footer/Footer.component.tsx
+++ b/apps/landing/src/components/common/Footer/Footer.component.tsx
@@ -21,16 +21,24 @@ const Footer = () => (
         >
           <Image src={createSvgUrl('common')('github-dark')} alt="" width={32} height={32} />
         </a>
-        <a href="mailto:recruit.mashup@gmail.com" aria-label="mash up email">
-          <Image src={createSvgUrl('common')('mail-dark')} alt="" width={32} height={32} />
-        </a>
         <a
-          href="https://mash-up.tistory.com/"
+          href="https://www.instagram.com/official_mashup_/"
           target="_blank"
           rel="noreferrer"
-          aria-label="mash up tistory"
+          aria-label="mash up instagram"
         >
-          <Image src={createSvgUrl('common')('tistory-dark')} alt="" width={32} height={32} />
+          <Image src={createSvgUrl('common')('instagram-dark')} alt="" width={32} height={32} />
+        </a>
+        <a
+          href="https://www.facebook.com/mashupgroup/"
+          target="_blank"
+          rel="noreferrer"
+          aria-label="mash up facebook"
+        >
+          <Image src={createSvgUrl('common')('facebook-dark')} alt="" width={32} height={32} />
+        </a>
+        <a href="mailto:recruit.mashup@gmail.com" aria-label="mash up email">
+          <Image src={createSvgUrl('common')('mail-dark')} alt="" width={32} height={32} />
         </a>
         <a
           href="https://www.behance.net/Mash-Up/"
@@ -41,20 +49,12 @@ const Footer = () => (
           <Image src={createSvgUrl('common')('behance-dark')} alt="" width={32} height={32} />
         </a>
         <a
-          href="https://www.facebook.com/mashupgroup/"
+          href="https://mash-up.tistory.com/"
           target="_blank"
           rel="noreferrer"
-          aria-label="mash up facebook"
+          aria-label="mash up tistory"
         >
-          <Image src={createSvgUrl('common')('facebook-dark')} alt="" width={32} height={32} />
-        </a>
-        <a
-          href="https://www.instagram.com/official_mashup_/"
-          target="_blank"
-          rel="noreferrer"
-          aria-label="mash up instagram"
-        >
-          <Image src={createSvgUrl('common')('instagram-dark')} alt="" width={32} height={32} />
+          <Image src={createSvgUrl('common')('tistory-dark')} alt="" width={32} height={32} />
         </a>
       </Styled.ExternalLinkWrapper>
       <Styled.CopyRight>© Mash-Up 2024. Made in Seoul.</Styled.CopyRight>


### PR DESCRIPTION
## 변경사항

- 랜딩페이지 푸터의 외부링크 순서를 14기 시점 노출 우선순위에 따라 변경

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
