### PR TITLE
매숑이 팝콘 동작 개선

### DIFF
--- a/apps/webview/.eslintrc.js
+++ b/apps/webview/.eslintrc.js
@@ -1,4 +1,7 @@
 module.exports = {
   root: true,
   extends: ['custom'],
+  globals: {
+    NodeJS: true,
+  },
 };

--- a/apps/webview/app/_components/ErrorToast.tsx
+++ b/apps/webview/app/_components/ErrorToast.tsx
@@ -19,5 +19,6 @@ export const ErrorToast = ({ message }: { message: ReactNode }) => (
 );
 
 export const showErrorToast = (message: ReactNode) => {
+  toast.remove();
   toast.custom(<ErrorToast message={message} />, { duration: 3000 });
 };

--- a/apps/webview/app/mashong/[team]/_components/MashongRoomContainer.tsx
+++ b/apps/webview/app/mashong/[team]/_components/MashongRoomContainer.tsx
@@ -12,13 +12,13 @@ import { MashongRoom } from './MashongRoom';
 import { PopcornXpTracker } from './PopcornXpTracker';
 
 export const MashongRoomContainer = ({
-  availablePopcorn,
+  remainingPopcorn,
   currentLevel,
   currentXP,
   maxXP,
   platformName,
 }: {
-  availablePopcorn: number;
+  remainingPopcorn: number;
   currentLevel: keyof typeof levelName;
   currentXP: number;
   maxXP: number;
@@ -58,7 +58,7 @@ export const MashongRoomContainer = ({
         isButtonDisabled={isFeeding}
         currentXP={currentXP}
         maxXP={maxXP}
-        availablePopcorn={availablePopcorn}
+        remainingPopcorn={remainingPopcorn}
         currentLevel={currentLevel}
         onClick={handleFeeding}
       />

--- a/apps/webview/app/mashong/[team]/_components/MashongRoomContainer.tsx
+++ b/apps/webview/app/mashong/[team]/_components/MashongRoomContainer.tsx
@@ -37,7 +37,7 @@ export const MashongRoomContainer = ({
     }
   }, []);
 
-  const handleFeeding = () => {
+  const showFeedMotion = () => {
     debouncedSetFeeding(true);
 
     timeoutRef.current = setTimeout(() => {
@@ -60,7 +60,7 @@ export const MashongRoomContainer = ({
         maxXP={maxXP}
         remainingPopcorn={remainingPopcorn}
         currentLevel={currentLevel}
-        onClick={handleFeeding}
+        showFeedMotion={showFeedMotion}
       />
       <Toast />
     </div>

--- a/apps/webview/app/mashong/[team]/_components/PopcornToast.tsx
+++ b/apps/webview/app/mashong/[team]/_components/PopcornToast.tsx
@@ -23,6 +23,7 @@ const PopcornToast = ({ value }: { value: number }) => (
 );
 
 export const showPopcornToast = (value: number) => {
+  toast.remove();
   toast.custom(<PopcornToast value={value} />, {
     duration: 3000,
   });

--- a/apps/webview/app/mashong/[team]/_components/PopcornXpTracker.tsx
+++ b/apps/webview/app/mashong/[team]/_components/PopcornXpTracker.tsx
@@ -185,6 +185,9 @@ export const PopcornXpTracker = ({
         disabled={isButtonDisabled}
         onClick={handleFeedButtonClick}
         {...longPressAttrs}
+        onContextMenu={(e) => {
+          e.preventDefault();
+        }}
         className={css({
           background: levelUpAvailable ? '#6A36FF' : '#F5F1FF',
           padding: levelUpAvailable ? '16px 0 15px 0' : '8px 0px 7px 0',
@@ -197,6 +200,7 @@ export const PopcornXpTracker = ({
           height: 48,
           position: 'relative',
           overflow: 'hidden',
+          userSelect: 'none',
         })}
       >
         {levelUpAvailable ? (

--- a/apps/webview/app/mashong/[team]/_components/TopMenuButton.tsx
+++ b/apps/webview/app/mashong/[team]/_components/TopMenuButton.tsx
@@ -3,6 +3,8 @@
 import { useRouter } from 'next/navigation';
 import { PropsWithChildren, useState } from 'react';
 
+import { revalidateMashongMissionStatus } from '@/app/mashong/_actions/revalidateMashongMissionStatus';
+import { revalidateMashongStatus } from '@/app/mashong/_actions/revalidateMashongStatus';
 import { css } from '@/styled-system/css';
 import { styled } from '@/styled-system/jsx';
 import SvgImage from '@/ui/svg-image';
@@ -21,6 +23,8 @@ export const TopMenuButton = ({
     if (variant === 'checkin') {
       setIsSheetOpen(true);
     } else {
+      revalidateMashongStatus();
+      revalidateMashongMissionStatus();
       router.push('/mashong/mission-board');
     }
   };

--- a/apps/webview/app/mashong/[team]/_helpers/feedHandlers.ts
+++ b/apps/webview/app/mashong/[team]/_helpers/feedHandlers.ts
@@ -1,0 +1,76 @@
+import React from 'react';
+
+import { showErrorToast } from '@/app/_components/ErrorToast';
+import { showPopcornToast } from '@/app/mashong/[team]/_components/PopcornToast';
+
+import { FeedActionTypes, FeedState, FeedAction } from './useFeedProgress';
+
+export const handleOptimisticUpdate = (dispatch: React.Dispatch<FeedAction>) => {
+  dispatch({ type: FeedActionTypes.OPTIMISTIC_UPDATE });
+};
+
+export const handleFeedSuccess = (
+  dispatch: React.Dispatch<FeedAction>,
+  response: {
+    fed: boolean;
+    currentXP: number;
+    maxXP: number;
+    currentLevel: number;
+    remainingPopcorn: number;
+  },
+  prevState: FeedState,
+  onSuccess: () => void,
+) => {
+  updateFeedState(dispatch, response, prevState, onSuccess);
+};
+
+export const handleFeedUpdate = (
+  dispatch: React.Dispatch<FeedAction>,
+  response: {
+    fed: boolean;
+    currentXP: number;
+    maxXP: number;
+    currentLevel: number;
+    remainingPopcorn: number;
+  },
+) => {
+  updateFeedState(dispatch, response, null);
+};
+
+export const handleFeedFailure = (dispatch: React.Dispatch<FeedAction>, prevState: FeedState) => {
+  dispatch({
+    type: FeedActionTypes.UPDATE_FAILURE,
+    payload: { prevState },
+  });
+  showErrorToast('팝콘 주기를 실패했어요..');
+};
+
+const updateFeedState = (
+  dispatch: React.Dispatch<FeedAction>,
+  response: {
+    fed: boolean;
+    currentXP: number;
+    maxXP: number;
+    currentLevel: number;
+    remainingPopcorn: number;
+  },
+  prevState: FeedState | null,
+  onSuccess?: () => void,
+) => {
+  const { fed, currentXP, maxXP, currentLevel, remainingPopcorn } = response;
+  const isAutoRefetching = !prevState;
+
+  dispatch({
+    type: FeedActionTypes.UPDATE_SUCCESS,
+    payload: { currentXP, maxXP, currentLevel, remainingPopcorn },
+  });
+
+  if (isAutoRefetching) return;
+
+  if (!fed) {
+    throw new Error();
+  }
+
+  showPopcornToast(prevState.popcornConsumed + 1);
+  onSuccess?.();
+};

--- a/apps/webview/app/mashong/[team]/_helpers/feedHandlers.ts
+++ b/apps/webview/app/mashong/[team]/_helpers/feedHandlers.ts
@@ -1,8 +1,5 @@
 import React from 'react';
 
-import { showErrorToast } from '@/app/_components/ErrorToast';
-import { showPopcornToast } from '@/app/mashong/[team]/_components/PopcornToast';
-
 import { FeedActionTypes, FeedState, FeedAction } from './useFeedProgress';
 
 export const handleOptimisticUpdate = (dispatch: React.Dispatch<FeedAction>) => {
@@ -42,7 +39,6 @@ export const handleFeedFailure = (dispatch: React.Dispatch<FeedAction>, prevStat
     type: FeedActionTypes.UPDATE_FAILURE,
     payload: { prevState },
   });
-  showErrorToast('팝콘 주기를 실패했어요..');
 };
 
 const updateFeedState = (
@@ -71,6 +67,5 @@ const updateFeedState = (
     throw new Error();
   }
 
-  showPopcornToast(prevState.popcornConsumed + 1);
   onSuccess?.();
 };

--- a/apps/webview/app/mashong/[team]/_helpers/levelHandlers.ts
+++ b/apps/webview/app/mashong/[team]/_helpers/levelHandlers.ts
@@ -1,0 +1,11 @@
+import Cookies from 'js-cookie';
+import { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
+
+export const handleLevelUp = (router: AppRouterInstance) => (nextLevel: number) => {
+  router.push(`/mashong/evolution/${nextLevel}`);
+};
+
+export const handleNoPopcorn = (router: AppRouterInstance) => async () => {
+  router.push('/mashong/mission-board');
+  Cookies.set('popcornAlertSeen', '1');
+};

--- a/apps/webview/app/mashong/[team]/_helpers/useFeedLongPress.ts
+++ b/apps/webview/app/mashong/[team]/_helpers/useFeedLongPress.ts
@@ -1,0 +1,56 @@
+import { useLongPress } from '@uidotdev/usehooks';
+import { useRef, useState, useEffect } from 'react';
+
+export const useFeedLongPress = ({
+  onStart,
+  onFinish,
+}: {
+  onStart: () => void;
+  onFinish: () => void;
+}) => {
+  const intervalRef = useRef<NodeJS.Timeout>();
+  const [longPressActive, setLongPressActive] = useState(false);
+
+  const startLongPress = () => {
+    setLongPressActive(true);
+    intervalRef.current = setInterval(() => {
+      onStart();
+    }, 100);
+  };
+
+  const finishLongPress = async () => {
+    clearInterval(intervalRef.current);
+    await onFinish();
+    requestAnimationFrame(() => {
+      resetLongPress();
+    });
+  };
+
+  const cancelLongPress = () => {
+    clearInterval(intervalRef.current);
+    resetLongPress();
+  };
+
+  const resetLongPress = () => {
+    setLongPressActive(false);
+  };
+
+  const longPressAttrs = useLongPress(startLongPress, {
+    onFinish: finishLongPress,
+    onCancel: cancelLongPress,
+  });
+
+  useEffect(
+    () => () => {
+      clearInterval(intervalRef.current);
+    },
+    [],
+  );
+
+  return {
+    longPressActive,
+    longPressAttrs,
+  };
+};
+
+export default useFeedLongPress;

--- a/apps/webview/app/mashong/[team]/_helpers/useFeedProgress.ts
+++ b/apps/webview/app/mashong/[team]/_helpers/useFeedProgress.ts
@@ -8,7 +8,6 @@ export const FeedActionTypes = {
 
 export interface FeedState {
   currentXP: number;
-  popcornConsumed: number;
   remainingPopcorn: number;
   maxXP: number;
   currentLevel: number;
@@ -25,7 +24,6 @@ const feedReducer = (state: FeedState, action: FeedAction): FeedState => {
       return {
         ...state,
         currentXP: state.currentXP + 1,
-        popcornConsumed: state.popcornConsumed + 1,
         remainingPopcorn: state.remainingPopcorn - 1,
       };
     case FeedActionTypes.UPDATE_SUCCESS:

--- a/apps/webview/app/mashong/[team]/_helpers/useFeedProgress.ts
+++ b/apps/webview/app/mashong/[team]/_helpers/useFeedProgress.ts
@@ -1,0 +1,43 @@
+import { useReducer } from 'react';
+
+export const FeedActionTypes = {
+  OPTIMISTIC_UPDATE: 'FEED_POPCORN_OPTIMISTIC',
+  UPDATE_SUCCESS: 'FEED_POPCORN_SUCCESS',
+  UPDATE_FAILURE: 'FEED_POPCORN_FAILURE',
+} as const;
+
+export interface FeedState {
+  currentXP: number;
+  popcornConsumed: number;
+  remainingPopcorn: number;
+  maxXP: number;
+  currentLevel: number;
+}
+
+export type FeedAction =
+  | { type: typeof FeedActionTypes.OPTIMISTIC_UPDATE }
+  | { type: typeof FeedActionTypes.UPDATE_SUCCESS; payload: Partial<FeedState> }
+  | { type: typeof FeedActionTypes.UPDATE_FAILURE; payload: { prevState: FeedState } };
+
+const feedReducer = (state: FeedState, action: FeedAction): FeedState => {
+  switch (action.type) {
+    case FeedActionTypes.OPTIMISTIC_UPDATE:
+      return {
+        ...state,
+        currentXP: state.currentXP + 1,
+        popcornConsumed: state.popcornConsumed + 1,
+        remainingPopcorn: state.remainingPopcorn - 1,
+      };
+    case FeedActionTypes.UPDATE_SUCCESS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case FeedActionTypes.UPDATE_FAILURE:
+      return action.payload.prevState;
+    default:
+      return state;
+  }
+};
+
+export const useFeedProgress = (initialState: FeedState) => useReducer(feedReducer, initialState);

--- a/apps/webview/app/mashong/[team]/_helpers/useFeedStatusPolling.tsx
+++ b/apps/webview/app/mashong/[team]/_helpers/useFeedStatusPolling.tsx
@@ -1,0 +1,16 @@
+import { Dispatch } from 'react';
+import { useInterval } from 'usehooks-ts';
+
+import { handleFeedUpdate } from './feedHandlers';
+import { FeedAction } from './useFeedProgress';
+import { getMashongStatus } from '../_services/getMashongStatus';
+
+export function useFeedStatusPolling(dispatch: Dispatch<FeedAction>, delay: null | number) {
+  useInterval(async () => {
+    const response = await getMashongStatus();
+    if (response) {
+      // @ts-expect-error
+      handleFeedUpdate(dispatch, response);
+    }
+  }, delay);
+}

--- a/apps/webview/app/mashong/[team]/_services/getMashongStatus.ts
+++ b/apps/webview/app/mashong/[team]/_services/getMashongStatus.ts
@@ -1,0 +1,31 @@
+import Cookies from 'js-cookie';
+
+export const getMashongStatus = async () => {
+  try {
+    const authToken = Cookies.get('token');
+
+    if (!authToken) {
+      throw new Error(`유효한 인증 토큰이 필요합니다.`);
+    }
+
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_PATH}/v1/mashong/status`, {
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+      },
+      next: { tags: ['mashong-status'] },
+    });
+
+    const { data } = await res.json();
+
+    return {
+      remainingPopcorn: data.lastPopcornValue,
+      currentLevel: data.currentLevel,
+      currentXP: data.accumulatedPopcornValue,
+      maxXP: data.goalPopcornValue,
+      platformName: data.platformName,
+    };
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};

--- a/apps/webview/app/mashong/[team]/_services/postPopcornFeed.ts
+++ b/apps/webview/app/mashong/[team]/_services/postPopcornFeed.ts
@@ -1,0 +1,30 @@
+import Cookies from 'js-cookie';
+
+export const postPopcornFeed = async (popcornCount: number) => {
+  const authToken = Cookies.get('token');
+
+  if (!authToken) {
+    throw new Error(`유효한 인증 토큰이 필요합니다.`);
+  }
+
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_PATH}/v1/mashong/popcorn/feed`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      popcornCount,
+    }),
+  });
+
+  const { data } = await res.json();
+
+  return {
+    remainingPopcorn: data.lastPopcornValue,
+    currentLevel: data.currentLevel,
+    currentXP: data.accumulatedPopcornValue,
+    maxXP: data.currentLevelGoalPopcorn,
+    fed: data.fed,
+  };
+};

--- a/apps/webview/app/mashong/[team]/page.tsx
+++ b/apps/webview/app/mashong/[team]/page.tsx
@@ -36,13 +36,7 @@ async function getMashongStatus() {
     };
   } catch (error) {
     console.error(error);
-    return {
-      remainingPopcorn: 10,
-      currentLevel: 1,
-      currentXP: 80,
-      maxXP: 100,
-      platformName: 'Android',
-    };
+    return null;
   }
 }
 

--- a/apps/webview/app/mashong/[team]/page.tsx
+++ b/apps/webview/app/mashong/[team]/page.tsx
@@ -89,7 +89,7 @@ const Page = async ({ params }: { params: { team: string } }) => {
           <TopMenuButton variant="mission">미션</TopMenuButton>
         </styled.div>
         <MashongRoomContainer
-          availablePopcorn={lastPopcornValue}
+          remainingPopcorn={lastPopcornValue}
           currentLevel={currentLevel}
           currentXP={accumulatedPopcornValue}
           maxXP={goalPopcornValue}

--- a/apps/webview/app/mashong/[team]/page.tsx
+++ b/apps/webview/app/mashong/[team]/page.tsx
@@ -26,14 +26,22 @@ async function getMashongStatus() {
     });
 
     const { data } = await res.json();
-    return data;
+
+    return {
+      remainingPopcorn: data.lastPopcornValue,
+      currentLevel: data.currentLevel,
+      currentXP: data.accumulatedPopcornValue,
+      maxXP: data.goalPopcornValue,
+      platformName: data.platformName,
+    };
   } catch (error) {
     console.error(error);
     return {
-      accumulatedPopcornValue: 0,
+      remainingPopcorn: 10,
       currentLevel: 1,
-      goalPopcornValue: 0,
-      lastPopcornValue: 0,
+      currentXP: 80,
+      maxXP: 100,
+      platformName: 'Android',
     };
   }
 }
@@ -62,8 +70,7 @@ async function checkAttendance() {
 }
 
 const Page = async ({ params }: { params: { team: string } }) => {
-  const { accumulatedPopcornValue, currentLevel, goalPopcornValue, lastPopcornValue } =
-    await getMashongStatus();
+  const { currentXP, maxXP, remainingPopcorn, currentLevel } = await getMashongStatus();
 
   const platformName: string = params.team.toUpperCase();
   assert(isKeyOfObject(platformName, PLATFORM_NAME_MAP));
@@ -89,10 +96,10 @@ const Page = async ({ params }: { params: { team: string } }) => {
           <TopMenuButton variant="mission">미션</TopMenuButton>
         </styled.div>
         <MashongRoomContainer
-          remainingPopcorn={lastPopcornValue}
+          remainingPopcorn={remainingPopcorn}
           currentLevel={currentLevel}
-          currentXP={accumulatedPopcornValue}
-          maxXP={goalPopcornValue}
+          currentXP={currentXP}
+          maxXP={maxXP}
           platformName={platformName}
         />
       </styled.div>

--- a/apps/webview/app/mashong/_actions/feedPopcorn.ts
+++ b/apps/webview/app/mashong/_actions/feedPopcorn.ts
@@ -1,6 +1,5 @@
 'use server';
 
-import { revalidateTag } from 'next/cache';
 import { cookies } from 'next/headers';
 
 export const feedPopcorn = async () => {
@@ -23,8 +22,6 @@ export const feedPopcorn = async () => {
     });
 
     const { data } = await res.json();
-
-    revalidateTag('mashong-status');
 
     return data;
   } catch (error) {

--- a/apps/webview/app/mashong/_actions/feedPopcorn.ts
+++ b/apps/webview/app/mashong/_actions/feedPopcorn.ts
@@ -23,7 +23,13 @@ export const feedPopcorn = async () => {
 
     const { data } = await res.json();
 
-    return data;
+    return {
+      remainingPopcorn: data.lastPopcornValue,
+      currentLevel: data.currentLevel,
+      currentXP: data.accumulatedPopcornValue,
+      maxXP: data.currentLevelGoalPopcorn,
+      fed: data.fed,
+    };
   } catch (error) {
     console.error(error);
     return {

--- a/apps/webview/app/mashong/_actions/levelUp.ts
+++ b/apps/webview/app/mashong/_actions/levelUp.ts
@@ -1,7 +1,8 @@
 'use server';
 
-import { revalidateTag } from 'next/cache';
 import { cookies } from 'next/headers';
+
+import { revalidateMashongStatus } from './revalidateMashongStatus';
 
 export const levelUp = async (goalLevel: number) => {
   try {
@@ -24,7 +25,7 @@ export const levelUp = async (goalLevel: number) => {
 
     const { data } = await res.json();
 
-    revalidateTag('mashong-status');
+    revalidateMashongStatus();
 
     return data;
   } catch (error) {

--- a/apps/webview/package.json
+++ b/apps/webview/package.json
@@ -10,6 +10,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@uidotdev/usehooks": "^2.4.1",
     "constant": "*",
     "embla-carousel-react": "^8.1.6",
     "framer-motion": "11.2.10",

--- a/apps/webview/tsconfig.json
+++ b/apps/webview/tsconfig.json
@@ -16,6 +16,7 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "types": ["node"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1985,6 +1985,11 @@
     "@typescript-eslint/types" "7.2.0"
     eslint-visitor-keys "^3.4.1"
 
+"@uidotdev/usehooks@^2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@uidotdev/usehooks/-/usehooks-2.4.1.tgz#4b733eaeae09a7be143c6c9ca158b56cc1ea75bf"
+  integrity sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg==
+
 "@vue/compiler-core@3.4.19":
   version "3.4.19"
   resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.4.19.tgz#3161b1ede69da00f3ce8155dfab907a3eaa0515e"
@@ -6965,7 +6970,7 @@ string-argv@0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6982,6 +6987,15 @@ string-width@^3.0.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.1.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -7063,7 +7077,7 @@ stringify-entities@^1.0.1:
     is-alphanumerical "^1.0.0"
     is-hexadecimal "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7076,6 +7090,13 @@ strip-ansi@^5.1.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"


### PR DESCRIPTION
## 변경사항

- 기존 Next.js Revalidate로 인한 딜레이 개선
  - 클라이언트 상태 관리와 낙관적 업데이트를 적용
- 롱프레스 기능 추가
  - 디바운스를 적용해 연속 클릭 및 롱프레스 시 API 호출 1회로 제한
- 클릭 버그 수정
- 토스트 딜레이 개선

https://github.com/user-attachments/assets/3a446314-e2ed-4349-9800-7ccfbb118582

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 리팩토링
- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
