### PR TITLE
에러 페이지 수정

### DIFF
--- a/apps/webview/app/birthday/error.tsx
+++ b/apps/webview/app/birthday/error.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { styled } from '@/styled-system/jsx';
+import SvgImage from '@/ui/svg-image';
+
+import { TopNavigationButton } from '../mashong/[team]/_components/TopNavigationButton';
+
+const Error = ({ error }: { error: Error & { digest?: string } }) => {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <styled.div
+      display="flex"
+      flexDirection="column"
+      bg="gray.50"
+      maxWidth="768px"
+      mx="auto"
+      minH="100dvh"
+      pt="env(safe-area-inset-top)"
+      pb="env(safe-area-inset-bottom)"
+      position="relative"
+      justifyContent="center"
+      alignItems="center"
+      overflow="hidden"
+    >
+      <styled.header
+        height="56px"
+        position="absolute"
+        maxW="[768px]"
+        w="100%"
+        top="0"
+        left="[50%]"
+        translate="auto"
+        translateX="-1/2"
+        bg="gray.50"
+        zIndex="1"
+      >
+        <styled.div
+          display="flex"
+          flexDirection="row"
+          justifyContent="space-between"
+          alignItems="center"
+          h="full"
+          p="[8px]"
+        >
+          <TopNavigationButton actionType="routerBack" />
+        </styled.div>
+      </styled.header>
+      <SvgImage path="error" width={148} height={148} />
+      <styled.span
+        fontWeight="400"
+        fontSize="14px"
+        lineHeight="16.8px"
+        letterSpacing="-1%"
+        textAlign="center"
+      >
+        오류가 발생했어요...
+      </styled.span>
+    </styled.div>
+  );
+};
+
+export default Error;

--- a/apps/webview/app/mashong/error.tsx
+++ b/apps/webview/app/mashong/error.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { styled } from '@/styled-system/jsx';
+import SvgImage from '@/ui/svg-image';
+
+import { TopNavigationButton } from './[team]/_components/TopNavigationButton';
+
+const Error = ({ error }: { error: Error & { digest?: string } }) => {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <styled.div
+      display="flex"
+      flexDirection="column"
+      bg="gray.50"
+      maxWidth="768px"
+      mx="auto"
+      minH="100dvh"
+      pt="env(safe-area-inset-top)"
+      pb="env(safe-area-inset-bottom)"
+      position="relative"
+      justifyContent="center"
+      alignItems="center"
+      overflow="hidden"
+    >
+      <styled.header
+        height="56px"
+        position="absolute"
+        maxW="[768px]"
+        w="100%"
+        top="0"
+        left="[50%]"
+        translate="auto"
+        translateX="-1/2"
+        bg="gray.50"
+        zIndex="1"
+      >
+        <styled.div
+          display="flex"
+          flexDirection="row"
+          justifyContent="space-between"
+          alignItems="center"
+          h="full"
+          p="[8px]"
+        >
+          <TopNavigationButton actionType="routerBack" />
+        </styled.div>
+      </styled.header>
+      <SvgImage path="error" width={148} height={148} />
+      <styled.span
+        fontWeight="400"
+        fontSize="14px"
+        lineHeight="16.8px"
+        letterSpacing="-1%"
+        textAlign="center"
+      >
+        오류가 발생했어요...
+      </styled.span>
+    </styled.div>
+  );
+};
+
+export default Error;


### PR DESCRIPTION
## 변경사항

- 에러 페이지 누락 수정
- 현 버전에서 [global-error](https://nextjs.org/docs/app/building-your-application/routing/error-handling#handling-global-errors)가 동작하지 않는 [이슈](https://github.com/vercel/next.js/issues/55462#issuecomment-2422089357)가 있어 우선 라우트마다 추가했습니다

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가
- 버그 수정

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
