### PR TITLE
Feat: recruit link 관련 로직 변경

### DIFF
--- a/apps/landing/src/components/common/Navigation/Navigation.component.tsx
+++ b/apps/landing/src/components/common/Navigation/Navigation.component.tsx
@@ -16,7 +16,13 @@ const Navigation = () => (
         </li>
       ))}
     </Styled.NavigationList> */}
-    <Styled.JoinUsAnchor href="https://recruit.mash-up.kr">Join Us!</Styled.JoinUsAnchor>
+    <Styled.JoinUsAnchor
+      href="https://recruit.mash-up.kr"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Join Us!
+    </Styled.JoinUsAnchor>
   </Styled.Navigation>
 );
 

--- a/apps/landing/src/components/main/JoinRecruitCard/JoinRecruitCard.styled.ts
+++ b/apps/landing/src/components/main/JoinRecruitCard/JoinRecruitCard.styled.ts
@@ -8,7 +8,6 @@ export const JoinRecruitCard = styled.li`
     position: relative;
     min-width: 33.3rem;
     height: 30.3rem;
-    padding: 2.4rem;
     white-space: pre-wrap;
     background: linear-gradient(90deg, #ff3b5e 0.11%, #6046ff 99.8%);
     border-radius: 1rem;
@@ -28,14 +27,23 @@ export const JoinRecruitCard = styled.li`
     @media (max-width: ${theme.breakPoint.media.tabletS}) {
       min-width: 27.5rem;
       height: 25rem;
-      padding: 20px;
     }
   `}
 `;
 
 export const GoToRecruitLink = styled.a`
   ${({ theme }) => css`
+    position: relative;
+    z-index: ${theme.zIndex.content};
+    display: inline-block;
+    width: 100%;
+    height: 100%;
+    padding: 2.4rem;
     color: ${theme.colors.white};
+
+    @media (max-width: ${theme.breakPoint.media.tabletS}) {
+      padding: 2rem;
+    }
   `}
 `;
 

--- a/apps/landing/src/components/main/PlatformIntroduceSection/PlatformIntroduceSection.component.tsx
+++ b/apps/landing/src/components/main/PlatformIntroduceSection/PlatformIntroduceSection.component.tsx
@@ -84,6 +84,8 @@ const PlatformIntroduceSection = () => {
         >
           {introduceSlideArray}
           {introduceSlideArray}
+          {introduceSlideArray}
+          {introduceSlideArray}
         </Styled.IntroduceSlide>
       </Styled.PlatformSlideLayout>
     </Styled.PlatformIntroduceSection>

--- a/apps/landing/src/components/main/PlatformIntroduceSection/PlatformIntroduceSection.styled.tsx
+++ b/apps/landing/src/components/main/PlatformIntroduceSection/PlatformIntroduceSection.styled.tsx
@@ -193,7 +193,7 @@ export const IntroduceSlide = styled.ul<IntroduceSlideProps>`
     gap: 22px;
     padding-right: 22px;
     overflow-x: visible;
-    animation: ${infiniteSlideAnimation} 20s infinite linear;
+    animation: ${infiniteSlideAnimation} 40s infinite linear;
     animation-play-state: ${isAnimationPause ? 'paused' : 'running'};
   `}
 `;


### PR DESCRIPTION
## 변경사항

- Header의 Join Us link의 target을 _black로 변경
- PlatformSection recruit link의 클릭 범위를 확장
- PlatformSlide의 총 길이를 2배 확장

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 신규 기능 추가

### 체크리스트

- [x] Merge 할 브랜치가 올바른가?
