### PR TITLE
Fix: mobile viewport에서 리크루팅 배너의 높이가 3px 초과된것을 수정한다

### DIFF
--- a/apps/landing/src/components/common/RecruitingBanner/RecruitingBanner.styled.ts
+++ b/apps/landing/src/components/common/RecruitingBanner/RecruitingBanner.styled.ts
@@ -70,7 +70,7 @@ export const RecruitBannerTextContainer = styled.div`
     }
     @media (max-width: ${theme.breakPoint.media.tabletS}) {
       flex-flow: column nowrap;
-      gap: 0.3rem;
+      gap: 0.1rem;
       align-items: start;
     }
   `}
@@ -172,7 +172,7 @@ export const MashUpLogo = styled(MashUpLogoIcon)`
     @media (max-width: ${theme.breakPoint.media.tabletS}) {
       width: 1.6rem;
       height: 1.6rem;
-      margin-bottom: 3px;
+      margin-bottom: 2px;
     }
   `}
 `;


### PR DESCRIPTION
## 변경사항

- mobile viewport에서 리크루팅 배너의 높이가 3px 초과된것을 수정한다

### 작업 유형

<!--  작업 유형에 맞는 리스트만 제외하고 지워주시면 됩니다 :) 해당 주석은 지우지 않아도 돼요!-->

- 버그 수정


### 체크리스트

- [ ] Merge 할 브랜치가 올바른가?
